### PR TITLE
chore: add readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,74 +40,133 @@ func main() {
 }
 ```
 
-### Example 2: Interacting with a contract
-    
+### Example 2: Interacting with a contract + Delegated Transaction
+
+
+<details>
+  <summary>Expand</summary>
+
 ```golang
 package main
 
 import (
-	"log/slog"
-	"math/big"
-	"strings"
+    "log/slog"
+    "math/big"
+    "strings"
 
-	"github.com/darrenvechain/thor-go-sdk/solo"
-	"github.com/darrenvechain/thor-go-sdk/thorgo"
-	"github.com/darrenvechain/thor-go-sdk/txmanager"
-	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/common"
+    "github.com/darrenvechain/thor-go-sdk/solo"
+    "github.com/darrenvechain/thor-go-sdk/thorgo"
+    "github.com/darrenvechain/thor-go-sdk/txmanager"
+    "github.com/ethereum/go-ethereum/accounts/abi"
+    "github.com/ethereum/go-ethereum/common"
 )
 
 func main() {
-	thor, _ := thorgo.FromURL("http://localhost:8669")
+    thor, _ := thorgo.FromURL("http://localhost:8669")
 
-	// Load a contract
-	contractABI, _ := abi.JSON(strings.NewReader(vthoABI))
-	vtho := thor.Account(common.HexToAddress("0x0000000000000000000000000000456e65726779")).Contract(&contractABI)
+    // Load a contract
+    contractABI, _ := abi.JSON(strings.NewReader(vthoABI))
+    vtho := thor.Account(common.HexToAddress("0x0000000000000000000000000000456e65726779")).Contract(&contractABI)
 
-	// Create a delegated transaction manager
-	origin := txmanager.FromPK(solo.Keys()[0], thor)
-	gasPayer := txmanager.NewDelegator(solo.Keys()[1])
-	txSender := txmanager.NewDelegatedManager(thor, origin, gasPayer)
+    // Create a delegated transaction manager
+    origin := txmanager.FromPK(solo.Keys()[0], thor)
+    gasPayer := txmanager.NewDelegator(solo.Keys()[1])
+    txSender := txmanager.NewDelegatedManager(thor, origin, gasPayer)
 
-	// Create a new account to receive the tokens
-	recipient, _ := txmanager.GeneratePK(thor)
-	recipientBalance := new(big.Int)
+    // Create a new account to receive the tokens
+    recipient, _ := txmanager.GeneratePK(thor)
+    recipientBalance := new(big.Int)
 
-	// Call the balanceOf function
-	err := vtho.Call("balanceOf", &recipientBalance, recipient.Address())
-	slog.Info("recipient balance before", "balance", recipientBalance, "error", err)
+    // Call the balanceOf function
+    err := vtho.Call("balanceOf", &recipientBalance, recipient.Address())
+    slog.Info("recipient balance before", "balance", recipientBalance, "error", err)
 
-	// Send 1000 tokens to the recipient
-	tx, _ := vtho.Send(txSender, "transfer", recipient.Address(), big.NewInt(1000))
-	receipt, _ := tx.Wait()
-	slog.Info("receipt", "txID", receipt.Meta.TxID, "reverted", receipt.Reverted)
+    // Send 1000 tokens to the recipient
+    tx, _ := vtho.Send(txSender, "transfer", recipient.Address(), big.NewInt(1000))
+    receipt, _ := tx.Wait()
+    slog.Info("receipt", "txID", receipt.Meta.TxID, "reverted", receipt.Reverted)
 
-	// Call the balanceOf function again
-	err = vtho.Call("balanceOf", &recipientBalance, recipient.Address())
-	slog.Info("recipient balance after", "balance", recipientBalance, "error", err)
+    // Call the balanceOf function again
+    err = vtho.Call("balanceOf", &recipientBalance, recipient.Address())
+    slog.Info("recipient balance after", "balance", recipientBalance, "error", err)
 }
 
 var (
-	vthoABI = `[
-		{
-			"constant": true,
-			"inputs": [{"internalType": "address", "name": "account", "type": "address"}],
-			"name": "balanceOf",
-			"outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"constant": false,
-			"inputs": [
-				{"internalType": "address", "name": "recipient", "type": "address"},
-				{"internalType": "uint256", "name": "amount", "type": "uint256"}
-			],
-			"name": "transfer",
-			"outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
-			"stateMutability": "nonpayable",
-			"type": "function"
-		}
-	]`
+    vthoABI = `[
+        {
+            "constant": true,
+            "inputs": [{"internalType": "address", "name": "account", "type": "address"}],
+            "name": "balanceOf",
+            "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {"internalType": "address", "name": "recipient", "type": "address"},
+                {"internalType": "uint256", "name": "amount", "type": "uint256"}
+            ],
+            "name": "transfer",
+            "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        }
+    ]`
 )
 ```
+
+
+</details>
+    
+
+
+### Example 3: Multi Clause Transaction
+
+<details>
+  <summary>Expand</summary>
+
+```golang
+package main
+
+import (
+    "github.com/darrenvechain/thor-go-sdk/solo"
+    "github.com/darrenvechain/thor-go-sdk/thorgo"
+    "github.com/darrenvechain/thor-go-sdk/transaction"
+    "github.com/darrenvechain/thor-go-sdk/txmanager"
+    "github.com/ethereum/go-ethereum/accounts/abi"
+    "github.com/ethereum/go-ethereum/common"
+    "log/slog"
+    "math/big"
+    "strings"
+)
+
+func main() {
+    thor, _ := thorgo.FromURL("http://localhost:8669")
+
+    // Load a contract
+    contractABI, _ := abi.JSON(strings.NewReader(vthoABI))
+    vtho := thor.Account(common.HexToAddress("0x0000000000000000000000000000456e65726779")).Contract(&contractABI)
+
+    origin := txmanager.FromPK(solo.Keys()[0], thor)
+
+    // clause1
+    clause1, _ := vtho.AsClause("transfer", common.HexToAddress("0x87AA2B76f29583E4A9095DBb6029A9C41994E25B"), big.NewInt(1000000))
+    clause2, _ := vtho.AsClause("transfer", common.HexToAddress("0x87AA2B76f29583E4A9095DBb6029A9C41994E25B"), big.NewInt(1000000))
+
+    // Option 1 - Directly using the txmanager.Manager
+    tx, _ := origin.SendClauses([]*transaction.Clause{clause1, clause2})
+    receipt, _ := thor.Transaction(tx).Wait()
+    slog.Info("transaction receipt 1", "id", receipt.Meta.TxID, "reverted", receipt.Reverted)
+
+    // Option 2 - Using the transaction builder with txmanager.Signer
+    tx2, _ := thor.TxBuilder([]*transaction.Clause{clause1, clause2}, origin.Address()).
+        GasPriceCoef(255).
+        Send(origin)
+    receipt2, _ := tx2.Wait()
+    slog.Info("transaction receipt 2", "id", receipt2.Meta.TxID, "reverted", receipt2.Reverted)
+}
+```
+
+</details>
+

--- a/thorgo/transactions/txbuilder.go
+++ b/thorgo/transactions/txbuilder.go
@@ -166,7 +166,7 @@ func (b *Builder) Build() (*transaction.Transaction, error) {
 }
 
 type TxSigner interface {
-	SignTransaction(tx *transaction.Transaction) (*transaction.Transaction, error)
+	SignTransaction(tx *transaction.Transaction) ([]byte, error)
 }
 
 func (b *Builder) Send(signer TxSigner) (*Visitor, error) {
@@ -175,10 +175,11 @@ func (b *Builder) Send(signer TxSigner) (*Visitor, error) {
 		return nil, fmt.Errorf("failed to build transaction: %w", err)
 	}
 
-	tx, err = signer.SignTransaction(tx)
+	signature, err := signer.SignTransaction(tx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign transaction: %w", err)
 	}
+	tx = tx.WithSignature(signature)
 
 	res, err := b.client.SendTransaction(tx)
 	if err != nil {

--- a/txmanager/types.go
+++ b/txmanager/types.go
@@ -17,7 +17,6 @@ type Options struct {
 
 // Manager represents a transaction manager. It is used to send transactions to the blockchain
 type Manager interface {
-	Address() common.Address
 	SendClauses(clauses []*transaction.Clause) (common.Hash, error)
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the `Manager` and `TxSigner` interfaces, adjusting the return type of the `SignTransaction` method, and updating the transaction signing process. Additionally, it enhances the README with new examples, including a delegated transaction and a multi-clause transaction.

### Detailed summary
- Changed `TxSigner.SignTransaction` method return type from `(*transaction.Transaction, error)` to `([]byte, error)`.
- Updated transaction signing logic in `Send` method of `Builder`.
- Added new example in `README.md` for "Interacting with a contract" with a delegated transaction.
- Introduced a new example for "Multi Clause Transaction" in `README.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->